### PR TITLE
transferNFT test for token name management

### DIFF
--- a/contracts/contracts/SsdlabToken.sol
+++ b/contracts/contracts/SsdlabToken.sol
@@ -8,7 +8,7 @@ import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 contract SsdlabToken is ERC721, AccessControl {
     bytes32 public constant TEACHER_ROLE = keccak256("TEACHER_ROLE");
     bytes32 public constant STUDENTS_ROLE = keccak256("STUDENTS_ROLE"); 
-    uint256 private _nextTokenId;
+    uint256 private _nextTokenId = 0;
 
 
     // 貢献の詳細のマッピング
@@ -26,9 +26,10 @@ contract SsdlabToken is ERC721, AccessControl {
     }
 
     function safeMint(address to, string memory _tokenName) public returns (uint256) {
-        uint256 tokenId = _nextTokenId++;
+        uint256 tokenId = _nextTokenId;
         _safeMint(to, tokenId);
-        _tokenNames[tokenId] = _tokenName;
+        setTokenName(tokenId, _tokenName);
+        _nextTokenId++;
         return tokenId;
     }
 

--- a/contracts/test/transferNFT.ts
+++ b/contracts/test/transferNFT.ts
@@ -1,0 +1,47 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SsdlabToken__factory } from "../typechain-types";
+import { token } from "../typechain-types/@openzeppelin/contracts";
+
+async function deployFixture() {
+    const [teacher, student1, student2] = await ethers.getSigners();
+    const teacherAddress = await teacher.getAddress();
+    const student1Address = await student1.getAddress();
+    const student2Address = await student2.getAddress();
+    const SsdlabToken = await ethers.deployContract("SsdlabToken", [teacherAddress, student1Address]);
+    
+    return { SsdlabToken, teacher, student1, student2 };
+}
+
+describe("NFTのtransfer", function () {
+    it("should set and get the token name correctly", async function () {
+        const { SsdlabToken, teacher, student1, student2 } = await loadFixture(deployFixture);
+        const tokenName: any = "Frends Lost Token";
+
+        // student1がアドレスを登録
+        await SsdlabToken.setUserAddress("student1",student1.address);
+        // student2がアドレスを登録
+        await SsdlabToken.setUserAddress("student2",student2.address);
+        
+        // アドレスが登録されているか確認
+        // 登録したアドレスと取得したアドレスが一致しているか確認
+        expect(await SsdlabToken.getUserAddress("student1")).to.equal(student1.address);
+        expect(await SsdlabToken.getUserAddress("student2")).to.equal(student2.address);
+        
+        // student1がNFTを発行数
+        const tokenId = await SsdlabToken.connect(student1).safeMint(student1.address, tokenName);
+        
+        // tokenIdが1になっているか確認
+        expect(await SsdlabToken.balanceOf(student1.address)).to.equal(1);
+        
+        expect(await SsdlabToken.getTokenName(tokenId.value)).to.equal(tokenName);
+
+        // student1がstudent2にNFTを送る
+        await SsdlabToken.connect(student1).safeTransferFrom(student1.address, student2.address, tokenId.value);
+
+        // student2がNFTを受け取ったか確認
+        expect(await SsdlabToken.balanceOf(student2.address)).to.equal(1);
+    });
+
+});


### PR DESCRIPTION
This pull request includes changes to the `SsdlabToken` smart contract and adds new tests to verify the functionality of NFT transfers. The most important changes include initializing the `_nextTokenId` variable, modifying the `safeMint` function, and adding a new test file for NFT transfers.

Changes to `SsdlabToken` smart contract:

* [`contracts/contracts/SsdlabToken.sol`](diffhunk://#diff-3fa5b15dde4cd6bcc53436e2082d88e8dd66d86b9fbb23cdb65918e151b09ab8L11-R11): Initialized the `_nextTokenId` variable to 0.
* [`contracts/contracts/SsdlabToken.sol`](diffhunk://#diff-3fa5b15dde4cd6bcc53436e2082d88e8dd66d86b9fbb23cdb65918e151b09ab8L29-R32): Modified the `safeMint` function to set the token name using the `setTokenName` function and increment `_nextTokenId` after minting.

Addition of new test file:

* [`contracts/test/transferNFT.ts`](diffhunk://#diff-c4d379e16f9f9ea06d6036896ea0a72a2413b94a4ded0e6c2a01b45bcd9bd782R1-R47): Added a new test file to verify the functionality of NFT transfers, including setting and getting token names, and transferring NFTs between addresses.