### PR TITLE
Add transferEther test for Ether transfer functionality

### DIFF
--- a/contracts/contracts/SsdlabToken.sol
+++ b/contracts/contracts/SsdlabToken.sol
@@ -10,7 +10,6 @@ contract SsdlabToken is ERC721, AccessControl {
     bytes32 public constant STUDENTS_ROLE = keccak256("STUDENTS_ROLE"); 
     uint256 private _nextTokenId = 0;
 
-
     // 貢献の詳細のマッピング
     mapping(uint256 => string) private _tokenNames;
 

--- a/contracts/test/transferEther.ts
+++ b/contracts/test/transferEther.ts
@@ -1,0 +1,30 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SsdlabToken__factory } from "../typechain-types";
+import { token } from "../typechain-types/@openzeppelin/contracts";
+
+async function deployFixture() {
+    const [teacher, student1, student2] = await ethers.getSigners();
+    const teacherAddress = await teacher.getAddress();
+    const student1Address = await student1.getAddress();
+    // const student2Address = await student2.getAddress(); // Removed as it's unused
+    const SsdlabToken = await ethers.deployContract("SsdlabToken", [teacherAddress, student1Address]);
+    
+    return { SsdlabToken, teacher, student1, student2 };
+}
+
+describe("Etherのtransfer", function () {
+    it("should set and get the token name correctly", async function () {
+        const { teacher, student1 } = await loadFixture(deployFixture);
+        const balancet = await ethers.provider.getBalance(teacher.address);
+        console.log(balancet);
+        // teacherがstudent1にEtherを送る
+        await teacher.sendTransaction({
+        to: student1.address,
+        value: ethers.parseEther("5.0"), 
+        });
+        const balance = await ethers.provider.getBalance(student1.address);
+        console.log(balance);
+    });
+});


### PR DESCRIPTION
This pull request includes changes to the `SsdlabToken` smart contract and the addition of a new test file `transferEther.ts`. The changes focus on improving the contract's structure and adding a new test for Ether transfers.

### Contract improvements:
* Removed an unnecessary blank line in the `SsdlabToken` contract to improve code readability. (`contracts/contracts/SsdlabToken.sol`)

### Test additions:
* Added a new test file `transferEther.ts` to test Ether transfers between accounts. This includes importing necessary libraries, deploying the contract, and writing a test case for transferring Ether from one account to another. (`contracts/test/transferEther.ts`)